### PR TITLE
TD-1526: add support for EIP-712 bulk listing types

### DIFF
--- a/signer/core/apitypes/signed_data_internal_test.go
+++ b/signer/core/apitypes/signed_data_internal_test.go
@@ -240,3 +240,49 @@ func TestConvertAddressDataToSlice(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTypedDataArrayValidate(t *testing.T) {
+	t.Parallel()
+
+	typedData := TypedData{
+		Types: Types{
+			"BulkOrder": []Type{
+				// Should be able to accept fixed size arrays
+				{Name: "tree", Type: "OrderComponents[2][2]"},
+			},
+			"OrderComponents": []Type{
+				{Name: "offerer", Type: "address"},
+				{Name: "amount", Type: "uint8"},
+			},
+			"EIP712Domain": []Type{
+				{Name: "name", Type: "string"},
+				{Name: "version", Type: "string"},
+				{Name: "chainId", Type: "uint8"},
+				{Name: "verifyingContract", Type: "address"},
+			},
+		},
+		PrimaryType: "BulkOrder",
+		Domain: TypedDataDomain{
+			VerifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+		},
+		Message: TypedDataMessage{},
+	}
+
+	if err := typedData.validate(); err != nil {
+		t.Errorf("expected typed data to pass validation, got: %v", err)
+	}
+
+	// Should be able to accept dynamic arrays
+	typedData.Types["BulkOrder"][0].Type = "OrderComponents[]"
+
+	if err := typedData.validate(); err != nil {
+		t.Errorf("expected typed data to pass validation, got: %v", err)
+	}
+
+	// Should be able to accept standard types
+	typedData.Types["BulkOrder"][0].Type = "OrderComponents"
+
+	if err := typedData.validate(); err != nil {
+		t.Errorf("expected typed data to pass validation, got: %v", err)
+	}
+}

--- a/signer/core/apitypes/types.go
+++ b/signer/core/apitypes/types.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Za-z](\w*)(\[\])?$`)
+var typedDataReferenceTypeRegexp = regexp.MustCompile(`^[A-Za-z](\w*)(\[\d*\])*$`)
 
 type ValidationInfo struct {
 	Typ     string `json:"type"`
@@ -216,8 +216,9 @@ func (t *Type) isArray() bool {
 // typeName returns the canonical name of the type. If the type is 'Person[]', then
 // this method returns 'Person'
 func (t *Type) typeName() string {
-	if strings.HasSuffix(t.Type, "[]") {
-		return strings.TrimSuffix(t.Type, "[]")
+	if strings.Contains(t.Type, "[") {
+		re := regexp.MustCompile(`\[\d*\]`)
+		return re.ReplaceAllString(t.Type, "")
 	}
 	return t.Type
 }


### PR DESCRIPTION
Bulk listing types can reference a tree structure from the primary type in the EIP-712 object, this currently works out of the box in typescript and the SDK however fails in `go-ethereum`. This package currently does not allow for types to be declared as fixed-sized arrays, so when a bulk listing tree structure is declared, e.g. `OrderComponents[2][2]` validation will fail. This change adds fixed-size arrays to be expected along with already supported dynamic arrays. 

Seaport ref for bulk order structure - https://github.com/ProjectOpenSea/seaport/blob/main/docs/SeaportDocumentation.md#bulk-order-signing-and-structure 